### PR TITLE
Fix/msi multi stock

### DIFF
--- a/Cron/UpdateStockFilter.php
+++ b/Cron/UpdateStockFilter.php
@@ -4,7 +4,6 @@ namespace Nordcomputer\Stockfilter\Cron;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ResourceConnection;
 use Psr\Log\LoggerInterface;
-use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\InventoryApi\Api\StockRepositoryInterface;
 use Magento\Framework\Module\Manager;
 use Magento\Framework\ObjectManagerInterface;
@@ -28,11 +27,9 @@ class UpdateStockFilter
         $this->scopeConfig = $scopeConfig;
         $this->resourceConnection = $resourceConnection;
         $this->logger = $logger;
-        $this->searchCriteriaBuilder = null;
         $this->stockRepository = null;
 
         if($moduleManager->isEnabled('Magento_InventoryApi')) {
-            $this->searchCriteriaBuilder = $objectManager->get(SearchCriteriaBuilder::class);
             $this->stockRepository = $objectManager->get(StockRepositoryInterface::class);
         }
     }
@@ -72,7 +69,7 @@ class UpdateStockFilter
 
     public function getNumberOfStocks() {
         // Is MSI enabled?
-		if($this->stockRepository == null || $this->searchCriteriaBuilder == null) {
+		if($this->stockRepository == null) {
             return 0;
         }
         try {

--- a/Cron/UpdateStockFilter.php
+++ b/Cron/UpdateStockFilter.php
@@ -74,7 +74,7 @@ class UpdateStockFilter
         }
         try {
             return $this->stockRepository->getList()->getTotalCount();
-        } catch (Exception $exception) {
+        } catch (\Exception $exception) {
             $this->logger->error('Nordcomputer_Stockfilter: Error while getting number of stocks: ' . $exception->getMessage());
         }
         return 0;

--- a/Cron/UpdateStockFilter.php
+++ b/Cron/UpdateStockFilter.php
@@ -69,7 +69,7 @@ class UpdateStockFilter
 
     public function getNumberOfStocks() {
         // Is MSI enabled?
-		if($this->stockRepository == null) {
+        if($this->stockRepository == null) {
             return 0;
         }
         try {

--- a/Cron/UpdateStockFilter.php
+++ b/Cron/UpdateStockFilter.php
@@ -3,19 +3,38 @@ namespace Nordcomputer\Stockfilter\Cron;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\ResourceConnection;
+use Psr\Log\LoggerInterface;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\InventoryApi\Api\StockRepositoryInterface;
+use Magento\Framework\Module\Manager;
+use Magento\Framework\ObjectManagerInterface;
 
 class UpdateStockFilter
 {
     /**
      * @param ScopeConfigInterface $scopeConfig
      * @param ResourceConnection $resourceConnection
+     * @param Manager $moduleManager
+     * @param ObjectManagerInterface $objectManager
+     * @param LoggerInterface $logger
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-        ResourceConnection $resourceConnection
+        ResourceConnection $resourceConnection,
+        Manager $moduleManager,
+        ObjectManagerInterface $objectManager,
+        LoggerInterface $logger
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->resourceConnection = $resourceConnection;
+        $this->logger = $logger;
+        $this->searchCriteriaBuilder = null;
+        $this->stockRepository = null;
+
+        if($moduleManager->isEnabled('Magento_InventoryApi')) {
+            $this->searchCriteriaBuilder = $objectManager->get(SearchCriteriaBuilder::class);
+            $this->stockRepository = $objectManager->get(StockRepositoryInterface::class);
+        }
     }
     /**
      * Executes Cronjob for updating 'stock_filter' parameter
@@ -26,12 +45,41 @@ class UpdateStockFilter
             $connection = $this->resourceConnection->getConnection();
             $table = $connection->getTableName('catalog_product_entity_int');
             // Update query
-            $query = "UPDATE " . $table . " t
-            JOIN cataloginventory_stock_status a ON a.product_id = t.entity_id
-            JOIN eav_attribute ap ON ap.attribute_id = t.attribute_id
-            SET value = stock_status WHERE attribute_code = 'filter_stock'";
+            if($this->getNumberOfStocks() > 1) {
+                // MSI fix in case of more than one stock. Source: https://magento.stackexchange.com/a/332557
+                $query = "UPDATE " . $table . " AS t 
+                JOIN eav_attribute ea ON ea.attribute_id = t.attribute_id 
+                JOIN 
+                    (SELECT t.value_id,t.entity_id,t.value,MAX(a.quantity) AS max_qty, MAX(a.status) AS max_status,MIN(a.status) AS min_status 
+                    FROM catalog_product_entity_int t
+                    JOIN catalog_product_entity cpe ON cpe.entity_id = t.entity_id
+                    JOIN inventory_source_item a ON a.sku = cpe.sku
+                    JOIN eav_attribute ap ON ap.attribute_id = t.attribute_id
+                    WHERE attribute_code = 'filter_stock'
+                    GROUP BY t.entity_id) 
+                AS TEMP_TABLE ON TEMP_TABLE.value_id = t.value_id SET t.value = IF(TEMP_TABLE.max_qty > 0 AND TEMP_TABLE.max_status = 1, 1, 0);";
+            } else {
+                // Non-MSI query
+                $query = "UPDATE " . $table . " t
+                JOIN cataloginventory_stock_status a ON a.product_id = t.entity_id
+                JOIN eav_attribute ap ON ap.attribute_id = t.attribute_id
+                SET value = stock_status WHERE attribute_code = 'filter_stock'";
+            }
             $connection->query($query);
         }
         return $this;
+    }
+
+    public function getNumberOfStocks() {
+        // Is MSI enabled?
+		if($this->stockRepository == null || $this->searchCriteriaBuilder == null) {
+            return 0;
+        }
+        try {
+            return $this->stockRepository->getList()->getTotalCount();
+        } catch (Exception $exception) {
+            $this->logger->error('Nordcomputer_Stockfilter: Error while getting number of stocks: ' . $exception->getMessage());
+        }
+        return 0;
     }
 }


### PR DESCRIPTION
PR with changes related to issue #13 

Tested on:
Magento 2.4.4 - Disabled MSI.
Magento 2.4.3 - Enabled MSI.

I think the code is self explanatory but will jot down a few technical things.

The issue appears (as noted [here](https://magento.stackexchange.com/a/332557)) only when there are more than 1, stocks define (more than the `default`). So we do a check on the number of stocks, and in case they are more than one, we use a bit more complex query to get the data from the `inventory_source_item` table. 

This table contains a row for each source of this stock, so we use the `MAX` function on both `status` (`in-stock` / `out-of-stock` dropdown) and `quantity` (quantity does not depend on status), and in case both the Maximum `status` is `1` and Maximum `quantity` is more than 0, we conclude that this item is `In Stock` for the filter.

While using `ObjectManager` is generally discouraged, here it is used because on a site without enabled MSI the cron job was failing on the constructor. So we use `Module\Manager` to see if the `Magento_InventoryApi` module is enabled, in case it is, we get our needed classes from the `Object Manager` otherwise, they are left at `null` which we handle first thing in the function.